### PR TITLE
ADMIN 세션 관리 API 및 문의 답변 API 구현

### DIFF
--- a/src/main/java/koza/licensemanagementservice/domain/license/repository/LicenseRepositoryCustom.java
+++ b/src/main/java/koza/licensemanagementservice/domain/license/repository/LicenseRepositoryCustom.java
@@ -4,6 +4,7 @@ package koza.licensemanagementservice.domain.license.repository;
 import koza.licensemanagementservice.domain.license.dto.response.LicenseAdminSummaryResponse;
 import koza.licensemanagementservice.domain.license.entity.License;
 import koza.licensemanagementservice.domain.license.repository.condition.LicenseSearchCondition;
+import koza.licensemanagementservice.domain.session.dto.request.SessionSearchCondition;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -18,4 +19,6 @@ public interface LicenseRepositoryCustom {
     Page<License> findByMemberId(Long memberId, String search, Boolean hasActiveSession, Integer expireWithin, Pageable pageable);
     Page<License> findBySoftwareId(Long softwareId, String search, Boolean hasActiveSession, Pageable pageable);
     Page<LicenseAdminSummaryResponse> findByAllCondition(LicenseSearchCondition condition, Pageable pageable);
+
+    Page<License> findActiveSessionLicensesByCondition(SessionSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/koza/licensemanagementservice/domain/license/repository/LicenseRepositoryCustomImpl.java
+++ b/src/main/java/koza/licensemanagementservice/domain/license/repository/LicenseRepositoryCustomImpl.java
@@ -11,6 +11,7 @@ import koza.licensemanagementservice.domain.license.dto.response.QLicenseAdminSu
 import koza.licensemanagementservice.domain.license.entity.License;
 import koza.licensemanagementservice.domain.license.repository.condition.LicenseSearchCondition;
 import koza.licensemanagementservice.domain.license.repository.condition.LicenseSearchTarget;
+import koza.licensemanagementservice.domain.session.dto.request.SessionSearchCondition;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -169,6 +170,56 @@ public class LicenseRepositoryCustomImpl implements LicenseRepositoryCustom {
                         searchFilter(condition.getTarget(), condition.getSearch()),
                         sessionFilter(condition.getHasActiveSession())
                 ).fetchOne();
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    @Override
+    public Page<License> findActiveSessionLicensesByCondition(SessionSearchCondition condition, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(license.hasActiveSession.isTrue());
+
+        if (condition.hasAnyFieldFilter()) {
+            if (condition.getOwnerEmail() != null)
+                builder.and(member.email.containsIgnoreCase(condition.getOwnerEmail()));
+            if (condition.getSoftwareName() != null)
+                builder.and(software.name.containsIgnoreCase(condition.getSoftwareName()));
+            if (condition.getLicenseKey() != null)
+                builder.and(license.licenseKey.containsIgnoreCase(condition.getLicenseKey()));
+            if (condition.getLicenseName() != null)
+                builder.and(license.name.containsIgnoreCase(condition.getLicenseName()));
+        } else if (condition.hasFullTextFilter()) {
+            String q = condition.getQ();
+            builder.and(
+                    member.email.containsIgnoreCase(q)
+                            .or(software.name.containsIgnoreCase(q))
+                            .or(license.licenseKey.containsIgnoreCase(q))
+                            .or(license.name.containsIgnoreCase(q))
+            );
+        }
+
+        if (condition.getStartedAfter() != null)
+            builder.and(license.latestActiveAt.goe(condition.getStartedAfter()));
+        if (condition.getStartedBefore() != null)
+            builder.and(license.latestActiveAt.loe(condition.getStartedBefore()));
+
+        List<License> content = jpaQueryFactory
+                .selectFrom(license)
+                .join(license.software, software).fetchJoin()
+                .join(software.member, member).fetchJoin()
+                .where(builder)
+                .orderBy(getOrderSpecifier(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory
+                .select(license.count())
+                .from(license)
+                .leftJoin(license.software, software)
+                .leftJoin(software.member, member)
+                .where(builder)
+                .fetchOne();
+
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 

--- a/src/main/java/koza/licensemanagementservice/domain/qna/controller/QnaAdminController.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/controller/QnaAdminController.java
@@ -1,0 +1,56 @@
+package koza.licensemanagementservice.domain.qna.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import koza.licensemanagementservice.auth.dto.CustomUser;
+import koza.licensemanagementservice.domain.qna.dto.request.QnaAdminSearchCondition;
+import koza.licensemanagementservice.domain.qna.dto.request.QnaAnswerRequest;
+import koza.licensemanagementservice.domain.qna.dto.response.QnaAdminListResponse;
+import koza.licensemanagementservice.domain.qna.dto.response.QnaDetailResponse;
+import koza.licensemanagementservice.domain.qna.service.QnaAdminService;
+import koza.licensemanagementservice.domain.qna.service.QnaService;
+import koza.licensemanagementservice.global.common.ApiResponse;
+import koza.licensemanagementservice.global.common.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/qna")
+@Tag(name = "QNA 관리자용 API", description = "관리자용 Q&A 조회/답변 API")
+public class QnaAdminController {
+    private final QnaAdminService qnaAdminService;
+    private final QnaService qnaService;
+
+    @Operation(summary = "관리자 문의 목록", description = "status/필드 검색/페이징")
+    @GetMapping
+    public ResponseEntity<ApiResponse<?>> getQuestions(@ModelAttribute QnaAdminSearchCondition condition,
+                                                        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)
+                                                        Pageable pageable) {
+        Page<QnaAdminListResponse> page = qnaAdminService.getQuestions(condition, pageable);
+        return ResponseEntity.ok(ApiResponse.success(PageResponse.from(page)));
+    }
+
+    @Operation(summary = "관리자 문의 단건 조회")
+    @GetMapping("/{qnaId}")
+    public ResponseEntity<ApiResponse<?>> getQuestionDetail(@PathVariable Long qnaId) {
+        QnaDetailResponse detail = qnaService.getQuestionDetail(qnaId);
+        return ResponseEntity.ok(ApiResponse.success(detail));
+    }
+
+    @Operation(summary = "답변 제출", description = "관리자가 문의에 답변 저장")
+    @PostMapping("/{qnaId}/answer")
+    public ResponseEntity<ApiResponse<?>> submitAnswer(@AuthenticationPrincipal CustomUser user,
+                                                        @PathVariable Long qnaId,
+                                                        @RequestBody @Valid QnaAnswerRequest request) {
+        QnaDetailResponse detail = qnaService.submitAnswer(user, qnaId, request);
+        return ResponseEntity.ok(ApiResponse.success(detail));
+    }
+}

--- a/src/main/java/koza/licensemanagementservice/domain/qna/dto/request/QnaAdminSearchCondition.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/dto/request/QnaAdminSearchCondition.java
@@ -1,0 +1,23 @@
+package koza.licensemanagementservice.domain.qna.dto.request;
+
+import koza.licensemanagementservice.domain.qna.entity.QnaStatus;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class QnaAdminSearchCondition {
+    private List<QnaStatus> status;
+    private String q;
+    private String title;
+    private String authorEmail;
+    private String softwareName;
+
+    public boolean hasAnyFieldFilter() {
+        return title != null || authorEmail != null || softwareName != null;
+    }
+
+    public boolean hasFullTextFilter() {
+        return q != null && !q.isBlank();
+    }
+}

--- a/src/main/java/koza/licensemanagementservice/domain/qna/dto/request/QnaAdminSearchCondition.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/dto/request/QnaAdminSearchCondition.java
@@ -1,8 +1,12 @@
 package koza.licensemanagementservice.domain.qna.dto.request;
 
 import koza.licensemanagementservice.domain.qna.entity.QnaStatus;
+import koza.licensemanagementservice.global.error.BusinessException;
+import koza.licensemanagementservice.global.error.ErrorCode;
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -13,11 +17,32 @@ public class QnaAdminSearchCondition {
     private String authorEmail;
     private String softwareName;
 
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime createdAfter;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime createdBefore;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime answeredAfter;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime answeredBefore;
+
     public boolean hasAnyFieldFilter() {
         return title != null || authorEmail != null || softwareName != null;
     }
 
     public boolean hasFullTextFilter() {
         return q != null && !q.isBlank();
+    }
+
+    public void validateDateRanges() {
+        if (createdAfter != null && createdBefore != null && createdAfter.isAfter(createdBefore)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+        if (answeredAfter != null && answeredBefore != null && answeredAfter.isAfter(answeredBefore)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
     }
 }

--- a/src/main/java/koza/licensemanagementservice/domain/qna/dto/request/QnaAnswerRequest.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/dto/request/QnaAnswerRequest.java
@@ -2,6 +2,7 @@ package koza.licensemanagementservice.domain.qna.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class QnaAnswerRequest {
     @NotBlank(message = "답변 내용은 필수입니다.")
+    @Size(max = 2000, message = "답변은 2000자를 넘을 수 없습니다.")
     @Schema(description = "답변 내용", example = "안녕하세요, 확인 후 조치하겠습니다.")
     private String answer;
 }

--- a/src/main/java/koza/licensemanagementservice/domain/qna/dto/response/QnaAdminListResponse.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/dto/response/QnaAdminListResponse.java
@@ -1,0 +1,21 @@
+package koza.licensemanagementservice.domain.qna.dto.response;
+
+import koza.licensemanagementservice.domain.qna.entity.QnaStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class QnaAdminListResponse {
+    private Long qnaId;
+    private String title;
+    private String memberEmail;
+    private String softwareName;
+    private QnaStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime answeredAt;
+}

--- a/src/main/java/koza/licensemanagementservice/domain/qna/entity/QnaQuestion.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/entity/QnaQuestion.java
@@ -66,6 +66,7 @@ public class QnaQuestion extends BaseEntity {
     public void submitAnswer(String answer) {
         this.answer = answer;
         this.answeredAt = LocalDateTime.now();
+        this.status = QnaStatus.CLOSED;
     }
 
     public void changeStatus(QnaStatus status) {

--- a/src/main/java/koza/licensemanagementservice/domain/qna/repository/QnaQuestionRepositoryCustom.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/repository/QnaQuestionRepositoryCustom.java
@@ -1,5 +1,7 @@
 package koza.licensemanagementservice.domain.qna.repository;
 
+import koza.licensemanagementservice.domain.qna.dto.request.QnaAdminSearchCondition;
+import koza.licensemanagementservice.domain.qna.dto.response.QnaAdminListResponse;
 import koza.licensemanagementservice.domain.qna.dto.response.QnaListResponse;
 import koza.licensemanagementservice.domain.qna.entity.QnaStatus;
 import org.springframework.data.domain.Page;
@@ -8,4 +10,6 @@ import org.springframework.data.domain.Pageable;
 public interface QnaQuestionRepositoryCustom {
     Page<QnaListResponse> findAllQuestions(String search, QnaStatus status, Pageable pageable);
     Page<QnaListResponse> findBySoftwareId(Long softwareId, String search, QnaStatus status, Pageable pageable);
+
+    Page<QnaAdminListResponse> findByAdminCondition(QnaAdminSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/koza/licensemanagementservice/domain/qna/repository/QnaQuestionRepositoryCustomImpl.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/repository/QnaQuestionRepositoryCustomImpl.java
@@ -1,18 +1,28 @@
 package koza.licensemanagementservice.domain.qna.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import koza.licensemanagementservice.domain.qna.dto.request.QnaAdminSearchCondition;
+import koza.licensemanagementservice.domain.qna.dto.response.QnaAdminListResponse;
 import koza.licensemanagementservice.domain.qna.dto.response.QnaListResponse;
+import koza.licensemanagementservice.domain.qna.entity.QnaQuestion;
 import koza.licensemanagementservice.domain.qna.entity.QnaStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import static koza.licensemanagementservice.domain.member.entity.QMember.member;
 import static koza.licensemanagementservice.domain.qna.entity.QQnaQuestion.qnaQuestion;
+import static koza.licensemanagementservice.domain.software.entity.QSoftware.software;
 
 @RequiredArgsConstructor
 public class QnaQuestionRepositoryCustomImpl implements QnaQuestionRepositoryCustom {
@@ -68,5 +78,76 @@ public class QnaQuestionRepositoryCustomImpl implements QnaQuestionRepositoryCus
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    @Override
+    public Page<QnaAdminListResponse> findByAdminCondition(QnaAdminSearchCondition condition, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (condition.getStatus() != null && !condition.getStatus().isEmpty()) {
+            builder.and(qnaQuestion.status.in(condition.getStatus()));
+        }
+
+        if (condition.hasAnyFieldFilter()) {
+            if (condition.getTitle() != null)
+                builder.and(qnaQuestion.title.containsIgnoreCase(condition.getTitle()));
+            if (condition.getAuthorEmail() != null)
+                builder.and(member.email.containsIgnoreCase(condition.getAuthorEmail()));
+            if (condition.getSoftwareName() != null)
+                builder.and(software.name.containsIgnoreCase(condition.getSoftwareName()));
+        } else if (condition.hasFullTextFilter()) {
+            String q = condition.getQ();
+            builder.and(
+                    qnaQuestion.title.containsIgnoreCase(q)
+                            .or(member.email.containsIgnoreCase(q))
+                            .or(software.name.containsIgnoreCase(q))
+            );
+        }
+
+        List<QnaAdminListResponse> content = queryFactory
+                .select(Projections.constructor(QnaAdminListResponse.class,
+                        qnaQuestion.id,
+                        qnaQuestion.title,
+                        member.email,
+                        software.name,
+                        qnaQuestion.status,
+                        qnaQuestion.createAt,
+                        qnaQuestion.answeredAt
+                ))
+                .from(qnaQuestion)
+                .leftJoin(qnaQuestion.software, software)
+                .leftJoin(qnaQuestion.member, member)
+                .where(builder)
+                .orderBy(toOrderSpecifiers(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(qnaQuestion.count())
+                .from(qnaQuestion)
+                .leftJoin(qnaQuestion.software, software)
+                .leftJoin(qnaQuestion.member, member)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+        PathBuilder<QnaQuestion> path = new PathBuilder<>(QnaQuestion.class, "qnaQuestion");
+
+        if (sort.isUnsorted()) {
+            orders.add(new OrderSpecifier<>(Order.DESC, path.getComparable("createAt", java.time.LocalDateTime.class)));
+            return orders.toArray(OrderSpecifier[]::new);
+        }
+
+        for (Sort.Order order : sort) {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            String prop = "createdAt".equals(order.getProperty()) ? "createAt" : order.getProperty();
+            orders.add(new OrderSpecifier(direction, path.get(prop)));
+        }
+        return orders.toArray(OrderSpecifier[]::new);
     }
 }

--- a/src/main/java/koza/licensemanagementservice/domain/qna/repository/QnaQuestionRepositoryCustomImpl.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/repository/QnaQuestionRepositoryCustomImpl.java
@@ -4,12 +4,10 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import koza.licensemanagementservice.domain.qna.dto.request.QnaAdminSearchCondition;
 import koza.licensemanagementservice.domain.qna.dto.response.QnaAdminListResponse;
 import koza.licensemanagementservice.domain.qna.dto.response.QnaListResponse;
-import koza.licensemanagementservice.domain.qna.entity.QnaQuestion;
 import koza.licensemanagementservice.domain.qna.entity.QnaStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -104,6 +102,15 @@ public class QnaQuestionRepositoryCustomImpl implements QnaQuestionRepositoryCus
             );
         }
 
+        if (condition.getCreatedAfter() != null)
+            builder.and(qnaQuestion.createAt.goe(condition.getCreatedAfter()));
+        if (condition.getCreatedBefore() != null)
+            builder.and(qnaQuestion.createAt.loe(condition.getCreatedBefore()));
+        if (condition.getAnsweredAfter() != null)
+            builder.and(qnaQuestion.answeredAt.goe(condition.getAnsweredAfter()));
+        if (condition.getAnsweredBefore() != null)
+            builder.and(qnaQuestion.answeredAt.loe(condition.getAnsweredBefore()));
+
         List<QnaAdminListResponse> content = queryFactory
                 .select(Projections.constructor(QnaAdminListResponse.class,
                         qnaQuestion.id,
@@ -136,17 +143,21 @@ public class QnaQuestionRepositoryCustomImpl implements QnaQuestionRepositoryCus
 
     private OrderSpecifier<?>[] toOrderSpecifiers(Sort sort) {
         List<OrderSpecifier<?>> orders = new ArrayList<>();
-        PathBuilder<QnaQuestion> path = new PathBuilder<>(QnaQuestion.class, "qnaQuestion");
 
-        if (sort.isUnsorted()) {
-            orders.add(new OrderSpecifier<>(Order.DESC, path.getComparable("createAt", java.time.LocalDateTime.class)));
-            return orders.toArray(OrderSpecifier[]::new);
+        if (!sort.isUnsorted()) {
+            for (Sort.Order order : sort) {
+                Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+                String prop = order.getProperty();
+                if ("createdAt".equals(prop) || "createAt".equals(prop)) {
+                    orders.add(new OrderSpecifier<>(direction, qnaQuestion.createAt));
+                } else if ("answeredAt".equals(prop)) {
+                    orders.add(new OrderSpecifier<>(direction, qnaQuestion.answeredAt).nullsLast());
+                }
+            }
         }
 
-        for (Sort.Order order : sort) {
-            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
-            String prop = "createdAt".equals(order.getProperty()) ? "createAt" : order.getProperty();
-            orders.add(new OrderSpecifier(direction, path.get(prop)));
+        if (orders.isEmpty()) {
+            orders.add(new OrderSpecifier<>(Order.DESC, qnaQuestion.createAt));
         }
         return orders.toArray(OrderSpecifier[]::new);
     }

--- a/src/main/java/koza/licensemanagementservice/domain/qna/service/QnaAdminService.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/service/QnaAdminService.java
@@ -16,6 +16,7 @@ public class QnaAdminService {
 
     @Transactional(readOnly = true)
     public Page<QnaAdminListResponse> getQuestions(QnaAdminSearchCondition condition, Pageable pageable) {
+        condition.validateDateRanges();
         return qnaQuestionRepository.findByAdminCondition(condition, pageable);
     }
 }

--- a/src/main/java/koza/licensemanagementservice/domain/qna/service/QnaAdminService.java
+++ b/src/main/java/koza/licensemanagementservice/domain/qna/service/QnaAdminService.java
@@ -1,0 +1,21 @@
+package koza.licensemanagementservice.domain.qna.service;
+
+import koza.licensemanagementservice.domain.qna.dto.request.QnaAdminSearchCondition;
+import koza.licensemanagementservice.domain.qna.dto.response.QnaAdminListResponse;
+import koza.licensemanagementservice.domain.qna.repository.QnaQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class QnaAdminService {
+    private final QnaQuestionRepository qnaQuestionRepository;
+
+    @Transactional(readOnly = true)
+    public Page<QnaAdminListResponse> getQuestions(QnaAdminSearchCondition condition, Pageable pageable) {
+        return qnaQuestionRepository.findByAdminCondition(condition, pageable);
+    }
+}

--- a/src/main/java/koza/licensemanagementservice/domain/session/controller/SessionAdminController.java
+++ b/src/main/java/koza/licensemanagementservice/domain/session/controller/SessionAdminController.java
@@ -1,0 +1,61 @@
+package koza.licensemanagementservice.domain.session.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import koza.licensemanagementservice.domain.session.dto.request.SessionSearchCondition;
+import koza.licensemanagementservice.domain.session.dto.request.SessionTerminateRequest;
+import koza.licensemanagementservice.domain.session.dto.request.SessionTerminationsBulkRequest;
+import koza.licensemanagementservice.domain.session.dto.response.SessionAdminDetailResponse;
+import koza.licensemanagementservice.domain.session.dto.response.SessionAdminListResponse;
+import koza.licensemanagementservice.domain.session.dto.response.SessionBulkTerminationResponse;
+import koza.licensemanagementservice.domain.session.service.SessionAdminService;
+import koza.licensemanagementservice.global.common.ApiResponse;
+import koza.licensemanagementservice.global.common.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/sessions")
+@Tag(name = "세션 관리자용 API", description = "관리자용 세션 조회/종료 API")
+public class SessionAdminController {
+    private final SessionAdminService sessionAdminService;
+
+    @Operation(summary = "관리자 전체 세션 목록", description = "활성 세션 목록 조회 (필터/검색/페이지네이션)")
+    @GetMapping
+    public ResponseEntity<ApiResponse<?>> getSessions(@ModelAttribute SessionSearchCondition condition,
+                                                      @PageableDefault(sort = "startedAt", direction = Sort.Direction.DESC)
+                                                      Pageable pageable) {
+        Page<SessionAdminListResponse> page = sessionAdminService.getSessions(condition, pageable);
+        return ResponseEntity.ok(ApiResponse.success(PageResponse.from(page)));
+    }
+
+    @Operation(summary = "관리자 세션 상세", description = "userAgent 포함 상세 정보 반환")
+    @GetMapping("/{sessionId}")
+    public ResponseEntity<ApiResponse<?>> getSession(@PathVariable("sessionId") String sessionId) {
+        SessionAdminDetailResponse detail = sessionAdminService.getSession(sessionId);
+        return ResponseEntity.ok(ApiResponse.success(detail));
+    }
+
+    @Operation(summary = "세션 강제 종료", description = "관리자가 단일 세션을 종료")
+    @PostMapping("/{sessionId}/terminations")
+    public ResponseEntity<ApiResponse<?>> terminate(@PathVariable("sessionId") String sessionId,
+                                                    @RequestBody(required = false) @Valid SessionTerminateRequest request) {
+        sessionAdminService.terminate(sessionId, request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @Operation(summary = "세션 일괄 강제 종료", description = "관리자가 여러 세션을 한 번에 종료")
+    @PostMapping("/terminations")
+    public ResponseEntity<ApiResponse<?>> terminateBulk(@RequestBody @Valid SessionTerminationsBulkRequest request) {
+        SessionBulkTerminationResponse result = sessionAdminService.terminateBulk(request);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/koza/licensemanagementservice/domain/session/dto/request/SessionSearchCondition.java
+++ b/src/main/java/koza/licensemanagementservice/domain/session/dto/request/SessionSearchCondition.java
@@ -1,0 +1,30 @@
+package koza.licensemanagementservice.domain.session.dto.request;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Data
+public class SessionSearchCondition {
+    private String q;
+    private String ownerEmail;
+    private String softwareName;
+    private String licenseKey;
+    private String licenseName;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startedAfter;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startedBefore;
+
+    public boolean hasAnyFieldFilter() {
+        return ownerEmail != null || softwareName != null
+                || licenseKey != null || licenseName != null;
+    }
+
+    public boolean hasFullTextFilter() {
+        return q != null && !q.isBlank();
+    }
+}

--- a/src/main/java/koza/licensemanagementservice/domain/session/dto/request/SessionTerminateRequest.java
+++ b/src/main/java/koza/licensemanagementservice/domain/session/dto/request/SessionTerminateRequest.java
@@ -1,0 +1,16 @@
+package koza.licensemanagementservice.domain.session.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionTerminateRequest {
+    @Size(max = 500, message = "종료 사유는 500자를 넘을 수 없습니다.")
+    @Schema(description = "종료 사유", example = "세션 비정상 사용")
+    private String reason;
+}

--- a/src/main/java/koza/licensemanagementservice/domain/session/dto/request/SessionTerminationsBulkRequest.java
+++ b/src/main/java/koza/licensemanagementservice/domain/session/dto/request/SessionTerminationsBulkRequest.java
@@ -1,0 +1,23 @@
+package koza.licensemanagementservice.domain.session.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionTerminationsBulkRequest {
+    @NotEmpty(message = "종료할 세션 ID를 하나 이상 입력해주세요.")
+    @Schema(description = "종료할 세션 ID 목록 (UUID 문자열)")
+    private List<String> ids;
+
+    @Size(max = 500, message = "종료 사유는 500자를 넘을 수 없습니다.")
+    @Schema(description = "종료 사유", example = "일괄 종료")
+    private String reason;
+}

--- a/src/main/java/koza/licensemanagementservice/domain/session/dto/response/SessionAdminDetailResponse.java
+++ b/src/main/java/koza/licensemanagementservice/domain/session/dto/response/SessionAdminDetailResponse.java
@@ -1,0 +1,37 @@
+package koza.licensemanagementservice.domain.session.dto.response;
+
+import koza.licensemanagementservice.domain.session.dto.SessionValue;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SessionAdminDetailResponse {
+    private String sessionId;
+    private String memberEmail;
+    private String softwareName;
+    private String licenseKey;
+    private String licenseName;
+    private LocalDateTime startedAt;
+    private String ipAddress;
+    private String userAgent;
+
+    public static SessionAdminDetailResponse of(SessionValue session,
+                                                String memberEmail,
+                                                String softwareName,
+                                                String licenseKey,
+                                                String licenseName) {
+        return SessionAdminDetailResponse.builder()
+                .sessionId(session.getSessionId())
+                .memberEmail(memberEmail)
+                .softwareName(softwareName)
+                .licenseKey(licenseKey)
+                .licenseName(licenseName)
+                .startedAt(session.getVerifyAt())
+                .ipAddress(session.getIpAddress())
+                .userAgent(session.getUserAgent())
+                .build();
+    }
+}

--- a/src/main/java/koza/licensemanagementservice/domain/session/dto/response/SessionAdminListResponse.java
+++ b/src/main/java/koza/licensemanagementservice/domain/session/dto/response/SessionAdminListResponse.java
@@ -1,0 +1,35 @@
+package koza.licensemanagementservice.domain.session.dto.response;
+
+import koza.licensemanagementservice.domain.session.dto.SessionValue;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SessionAdminListResponse {
+    private String sessionId;
+    private String memberEmail;
+    private String softwareName;
+    private String licenseKey;
+    private String licenseName;
+    private LocalDateTime startedAt;
+    private String ipAddress;
+
+    public static SessionAdminListResponse of(SessionValue session,
+                                              String memberEmail,
+                                              String softwareName,
+                                              String licenseKey,
+                                              String licenseName) {
+        return SessionAdminListResponse.builder()
+                .sessionId(session.getSessionId())
+                .memberEmail(memberEmail)
+                .softwareName(softwareName)
+                .licenseKey(licenseKey)
+                .licenseName(licenseName)
+                .startedAt(session.getVerifyAt())
+                .ipAddress(session.getIpAddress())
+                .build();
+    }
+}

--- a/src/main/java/koza/licensemanagementservice/domain/session/dto/response/SessionBulkTerminationResponse.java
+++ b/src/main/java/koza/licensemanagementservice/domain/session/dto/response/SessionBulkTerminationResponse.java
@@ -1,0 +1,13 @@
+package koza.licensemanagementservice.domain.session.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SessionBulkTerminationResponse {
+    private int terminated;
+    private int failed;
+}

--- a/src/main/java/koza/licensemanagementservice/domain/session/service/SessionAdminService.java
+++ b/src/main/java/koza/licensemanagementservice/domain/session/service/SessionAdminService.java
@@ -1,0 +1,147 @@
+package koza.licensemanagementservice.domain.session.service;
+
+import koza.licensemanagementservice.domain.license.entity.License;
+import koza.licensemanagementservice.domain.license.repository.LicenseRepository;
+import koza.licensemanagementservice.domain.session.dto.SessionValue;
+import koza.licensemanagementservice.domain.session.dto.request.SessionSearchCondition;
+import koza.licensemanagementservice.domain.session.dto.request.SessionTerminateRequest;
+import koza.licensemanagementservice.domain.session.dto.request.SessionTerminationsBulkRequest;
+import koza.licensemanagementservice.domain.session.dto.response.SessionAdminDetailResponse;
+import koza.licensemanagementservice.domain.session.dto.response.SessionAdminListResponse;
+import koza.licensemanagementservice.domain.session.dto.response.SessionBulkTerminationResponse;
+import koza.licensemanagementservice.domain.session.log.entity.ReleaseType;
+import koza.licensemanagementservice.global.error.BusinessException;
+import koza.licensemanagementservice.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SessionAdminService {
+    private final LicenseRepository licenseRepository;
+    private final SessionManager sessionManager;
+
+    @Transactional(readOnly = true)
+    public Page<SessionAdminListResponse> getSessions(SessionSearchCondition condition, Pageable pageable) {
+        Pageable resolved = applySortAlias(pageable);
+        Page<License> licenses = licenseRepository.findActiveSessionLicensesByCondition(condition, resolved);
+
+        List<SessionAdminListResponse> items = licenses.stream()
+                .map(this::toListResponse)
+                .filter(Objects::nonNull)
+                .toList();
+
+        return new PageImpl<>(items, resolved, licenses.getTotalElements());
+    }
+
+    @Transactional(readOnly = true)
+    public SessionAdminDetailResponse getSession(String sessionId) {
+        SessionValue session = sessionManager.getSession(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        License license = licenseRepository.findByIdWithSoftwareAndMember(session.getLicenseId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        return SessionAdminDetailResponse.of(
+                session,
+                license.getSoftware().getMember().getEmail(),
+                license.getSoftware().getName(),
+                license.getLicenseKey(),
+                license.getName()
+        );
+    }
+
+    @Transactional
+    public void terminate(String sessionId, SessionTerminateRequest request) {
+        SessionValue session = sessionManager.getSession(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        License license = licenseRepository.findByIdWithSoftwareAndMember(session.getLicenseId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        if (!license.hasActiveSession()) {
+            throw new BusinessException(ErrorCode.SESSION_ALREADY_TERMINATED);
+        }
+
+        terminateInternal(session.getSessionId(), license, request != null ? request.getReason() : null);
+    }
+
+    @Transactional
+    public SessionBulkTerminationResponse terminateBulk(SessionTerminationsBulkRequest request) {
+        int terminated = 0;
+        int failed = 0;
+
+        for (String sessionId : request.getIds()) {
+            try {
+                Optional<SessionValue> optSession = sessionManager.getSession(sessionId);
+                if (optSession.isEmpty()) {
+                    failed++;
+                    continue;
+                }
+                Optional<License> optLicense = licenseRepository.findByIdWithSoftwareAndMember(optSession.get().getLicenseId());
+                if (optLicense.isEmpty() || !optLicense.get().hasActiveSession()) {
+                    failed++;
+                    continue;
+                }
+                terminateInternal(sessionId, optLicense.get(), request.getReason());
+                terminated++;
+            } catch (Exception e) {
+                log.warn("세션 일괄 종료 실패: sessionId={}, cause={}", sessionId, e.getMessage());
+                failed++;
+            }
+        }
+        return SessionBulkTerminationResponse.builder()
+                .terminated(terminated)
+                .failed(failed)
+                .build();
+    }
+
+    private void terminateInternal(String sessionId, License license, String reason) {
+        license.release();
+        sessionManager.releaseSession(sessionId, license, ReleaseType.FORCE_CLOSE);
+        if (reason != null && !reason.isBlank()) {
+            log.info("관리자 세션 종료: sessionId={}, licenseId={}, reason={}", sessionId, license.getId(), reason);
+        }
+    }
+
+    private SessionAdminListResponse toListResponse(License license) {
+        return sessionManager.getSessionByLicenseId(license.getId())
+                .map(session -> SessionAdminListResponse.of(
+                        session,
+                        license.getSoftware().getMember().getEmail(),
+                        license.getSoftware().getName(),
+                        license.getLicenseKey(),
+                        license.getName()))
+                .orElse(null);
+    }
+
+    /**
+     * 스펙상 sort 키는 "startedAt" 이지만 License 엔티티에는 해당 컬럼이 없으므로
+     * 세션 시작 시각에 대응되는 license.latestActiveAt 로 치환한다.
+     */
+    private Pageable applySortAlias(Pageable pageable) {
+        if (pageable.getSort().isUnsorted()) {
+            return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                    Sort.by(Sort.Direction.DESC, "latestActiveAt"));
+        }
+
+        List<Sort.Order> translated = pageable.getSort().stream()
+                .map(o -> "startedAt".equals(o.getProperty())
+                        ? new Sort.Order(o.getDirection(), "latestActiveAt")
+                        : o)
+                .toList();
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(translated));
+    }
+}

--- a/src/main/java/koza/licensemanagementservice/global/common/PageResponse.java
+++ b/src/main/java/koza/licensemanagementservice/global/common/PageResponse.java
@@ -1,0 +1,52 @@
+package koza.licensemanagementservice.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.function.Function;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PageResponse<T> {
+    private List<T> items;
+    private Pagination pagination;
+
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return PageResponse.<T>builder()
+                .items(page.getContent())
+                .pagination(Pagination.from(page))
+                .build();
+    }
+
+    public static <S, T> PageResponse<T> from(Page<S> page, Function<S, T> mapper) {
+        return PageResponse.<T>builder()
+                .items(page.map(mapper).getContent())
+                .pagination(Pagination.from(page))
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Pagination {
+        private int page;
+        private int size;
+        private long totalItems;
+        private int totalPages;
+        private boolean hasNext;
+
+        public static Pagination from(Page<?> page) {
+            return Pagination.builder()
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalItems(page.getTotalElements())
+                    .totalPages(page.getTotalPages())
+                    .hasNext(page.hasNext())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/koza/licensemanagementservice/global/error/ErrorCode.java
+++ b/src/main/java/koza/licensemanagementservice/global/error/ErrorCode.java
@@ -42,6 +42,8 @@ public enum ErrorCode {
 
     // 세션 로직 예외
     EXPIRED_SESSION(403, "SESSION_001", "만료된 세션입니다."),
+    SESSION_NOT_FOUND(404, "SESSION_002", "세션을 찾을 수 없습니다."),
+    SESSION_ALREADY_TERMINATED(409, "SESSION_003", "이미 종료된 세션입니다."),
 
     // QNA 예외
     QNA_NOT_FOUND(404, "QNA_001", "질문을 찾을 수 없습니다."),


### PR DESCRIPTION
123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 관리자용 세션 관리 기능 추가: 활성 세션 목록 조회, 상세 조회, 개별/일괄 종료 지원
  * 관리자용 QnA 관리 기능 추가: 질문 목록 검색, 상세 조회, 답변 제출 기능
  * 세션 및 QnA 검색 기능 확대: 이메일, 소프트웨어명, 라이선스 키 등 다양한 필터링 옵션 추가
  * 페이지네이션 응답 형식 표준화

* **개선사항**
  * QnA 답변 길이 제한 추가 (최대 2,000자)
  * 세션 종료 사유 기록 기능 (최대 500자)

* **오류 처리**
  * 세션 미발견 및 중복 종료 오류 구분

<!-- end of auto-generated comment: release notes by coderabbit.ai -->